### PR TITLE
feat(ux): scroll-triggered and hover animations via motion v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
         "lucide-react": "^0.539.0",
+        "motion": "^12.40.0",
         "next": "^16.2.1",
         "next-intl": "^4.3.4",
         "react": "19.1.0",
@@ -4356,6 +4357,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5690,6 +5718,47 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "lucide-react": "^0.539.0",
+    "motion": "^12.40.0",
     "next": "^16.2.1",
     "next-intl": "^4.3.4",
     "react": "19.1.0",

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 import { CheckCircle2 } from 'lucide-react';
+import { FadeInUp, StaggerContainer, StaggerItem } from '@/components/ui/motion-wrappers';
 
 export default function AboutSection() {
   const t = useTranslations('About');
@@ -41,34 +42,40 @@ export default function AboutSection() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
           {/* Left: Bio + highlights */}
           <div>
-            <p className="section-label mb-4">{t('section_label')}</p>
-            <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 leading-tight mb-6">
-              {t('title')}
-            </h2>
-            <p className="text-zinc-400 leading-relaxed mb-8 text-[0.9375rem]">
-              {t('bio')}
-            </p>
+            <FadeInUp>
+              <p className="section-label mb-4">{t('section_label')}</p>
+              <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 leading-tight mb-6">
+                {t('title')}
+              </h2>
+              <p className="text-zinc-400 leading-relaxed mb-8 text-[0.9375rem]">
+                {t('bio')}
+              </p>
+            </FadeInUp>
 
-            <div className="space-y-4">
+            <StaggerContainer className="space-y-4">
               {highlights.map((h) => (
-                <div key={h.title} className="flex gap-3">
+                <StaggerItem key={h.title} className="flex gap-3">
                   <CheckCircle2 className="h-5 w-5 text-cyan-400 shrink-0 mt-0.5" />
                   <div>
                     <div className="text-sm font-medium text-zinc-200">{h.title}</div>
                     <div className="text-sm text-zinc-500 leading-snug mt-0.5">{h.desc}</div>
                   </div>
-                </div>
+                </StaggerItem>
               ))}
-            </div>
+            </StaggerContainer>
           </div>
 
           {/* Right: Experience timeline */}
           <div>
-            <p className="section-label mb-6">{t('exp_label')}</p>
-            <div className="space-y-4">
+            <FadeInUp>
+              <p className="section-label mb-6">{t('exp_label')}</p>
+            </FadeInUp>
+
+            <StaggerContainer className="space-y-4">
               {experience.map((role, i) => (
-                <div
+                <StaggerItem
                   key={i}
+                  hover
                   className={`bg-card border rounded-2xl p-5 card-glow ${
                     role.current ? 'border-cyan-400/40' : 'border-zinc-800'
                   }`}
@@ -90,9 +97,9 @@ export default function AboutSection() {
                     <div className="text-xs text-zinc-500 font-mono shrink-0 mt-0.5">{role.period}</div>
                   </div>
                   <p className="text-sm text-zinc-500 leading-relaxed">{role.desc}</p>
-                </div>
+                </StaggerItem>
               ))}
-            </div>
+            </StaggerContainer>
           </div>
         </div>
       </div>

--- a/src/components/sections/CaseStudiesSection.tsx
+++ b/src/components/sections/CaseStudiesSection.tsx
@@ -2,6 +2,7 @@ import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
+import { FadeInUp, StaggerContainer, StaggerItem } from '@/components/ui/motion-wrappers';
 
 export default function CaseStudiesSection() {
   const t = useTranslations('CaseStudies');
@@ -73,18 +74,21 @@ export default function CaseStudiesSection() {
   return (
     <section id="case-studies" className="py-24 border-t border-zinc-800/60">
       <div className="max-w-6xl mx-auto px-6">
-        <p className="section-label mb-4">{t('section_label')}</p>
-        <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 mb-3">
-          {t('title')}
-        </h2>
-        <p className="text-zinc-500 text-[0.9375rem] mb-12 max-w-2xl">
-          {t('subtitle')}
-        </p>
+        <FadeInUp>
+          <p className="section-label mb-4">{t('section_label')}</p>
+          <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 mb-3">
+            {t('title')}
+          </h2>
+          <p className="text-zinc-500 text-[0.9375rem] mb-12 max-w-2xl">
+            {t('subtitle')}
+          </p>
+        </FadeInUp>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+        <StaggerContainer className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
           {caseStudies.map((cs) => (
-            <div
+            <StaggerItem
               key={cs.slug}
+              hover
               className="bg-card border border-zinc-800 rounded-2xl p-6 flex flex-col card-glow"
             >
               {/* Category */}
@@ -124,9 +128,9 @@ export default function CaseStudiesSection() {
                 {t('read_more')}
                 <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-0.5 transition-transform" />
               </Link>
-            </div>
+            </StaggerItem>
           ))}
-        </div>
+        </StaggerContainer>
       </div>
     </section>
   );

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
 import { Github, Linkedin, MapPin } from 'lucide-react';
+import { FadeInUp, StaggerContainer, StaggerItem } from '@/components/ui/motion-wrappers';
 
 export default function HeroSection() {
   const t = useTranslations('Hero');
@@ -17,77 +18,84 @@ export default function HeroSection() {
     <section id="hero" className="grid-bg min-h-[90vh] flex items-center">
       <div className="max-w-6xl mx-auto px-6 py-24 w-full">
         {/* Available badge */}
-        <div className="flex items-center gap-2 mb-8">
-          <span className="relative flex h-2.5 w-2.5">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
-          </span>
-          <span className="text-sm text-zinc-400">{t('available')}</span>
-          <span className="text-zinc-700 mx-1">·</span>
-          <span className="flex items-center gap-1 text-sm text-zinc-500">
-            <MapPin className="h-3.5 w-3.5" />
-            {t('location')}
-          </span>
-        </div>
+        <FadeInUp>
+          <div className="flex items-center gap-2 mb-8">
+            <span className="relative flex h-2.5 w-2.5">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-500"></span>
+            </span>
+            <span className="text-sm text-zinc-400">{t('available')}</span>
+            <span className="text-zinc-700 mx-1">·</span>
+            <span className="flex items-center gap-1 text-sm text-zinc-500">
+              <MapPin className="h-3.5 w-3.5" />
+              {t('location')}
+            </span>
+          </div>
+        </FadeInUp>
 
         {/* Name */}
-        <h1 className="text-5xl md:text-7xl lg:text-8xl font-extrabold tracking-tight mb-5">
-          <span className="gradient-text">Mario</span>{' '}
-          <span className="text-zinc-100">de Jesus</span>
-        </h1>
+        <FadeInUp delay={0.1}>
+          <h1 className="text-5xl md:text-7xl lg:text-8xl font-extrabold tracking-tight mb-5">
+            <span className="gradient-text">Mario</span>{' '}
+            <span className="text-zinc-100">de Jesus</span>
+          </h1>
+        </FadeInUp>
 
         {/* Tagline */}
-        <p className="text-lg md:text-xl text-zinc-400 font-mono mb-6 tracking-wide">
-          {t('tagline')}
-        </p>
+        <FadeInUp delay={0.2}>
+          <p className="text-lg md:text-xl text-zinc-400 font-mono mb-6 tracking-wide">
+            {t('tagline')}
+          </p>
+        </FadeInUp>
 
         {/* Description */}
-        <p className="max-w-xl text-zinc-500 text-base leading-relaxed mb-10">
-          {t('description')}
-        </p>
+        <FadeInUp delay={0.3}>
+          <p className="max-w-xl text-zinc-500 text-base leading-relaxed mb-10">
+            {t('description')}
+          </p>
+        </FadeInUp>
 
         {/* CTAs */}
-        <div className="flex flex-wrap items-center gap-4 mb-16">
-          <a
-            href={`/${locale}/#case-studies`}
-            className="px-6 py-3 bg-cyan-400 text-zinc-900 font-semibold text-sm rounded-lg hover:bg-cyan-300 transition-colors"
-          >
-            {t('cta_work')}
-          </a>
-          <a
-            href="https://github.com/ramdel"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-5 py-3 border border-zinc-700 text-zinc-300 text-sm rounded-lg hover:border-zinc-500 hover:text-zinc-100 transition-colors"
-          >
-            <Github className="h-4 w-4" />
-            GitHub
-          </a>
-          <a
-            href="https://www.linkedin.com/in/ramdel"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-5 py-3 border border-zinc-700 text-zinc-300 text-sm rounded-lg hover:border-zinc-500 hover:text-zinc-100 transition-colors"
-          >
-            <Linkedin className="h-4 w-4" />
-            LinkedIn
-          </a>
-        </div>
+        <FadeInUp delay={0.4}>
+          <div className="flex flex-wrap items-center gap-4 mb-16">
+            <a
+              href={`/${locale}/#case-studies`}
+              className="px-6 py-3 bg-cyan-400 text-zinc-900 font-semibold text-sm rounded-lg hover:bg-cyan-300 transition-colors"
+            >
+              {t('cta_work')}
+            </a>
+            <a
+              href="https://github.com/ramdel"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-5 py-3 border border-zinc-700 text-zinc-300 text-sm rounded-lg hover:border-zinc-500 hover:text-zinc-100 transition-colors"
+            >
+              <Github className="h-4 w-4" />
+              GitHub
+            </a>
+            <a
+              href="https://www.linkedin.com/in/ramdel"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-5 py-3 border border-zinc-700 text-zinc-300 text-sm rounded-lg hover:border-zinc-500 hover:text-zinc-100 transition-colors"
+            >
+              <Linkedin className="h-4 w-4" />
+              LinkedIn
+            </a>
+          </div>
+        </FadeInUp>
 
         {/* Metrics grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StaggerContainer className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {metrics.map((metric) => (
-            <div
-              key={metric.label}
-              className="bg-card border border-zinc-800 rounded-2xl p-5 card-glow"
-            >
+            <StaggerItem key={metric.label} hover className="bg-card border border-zinc-800 rounded-2xl p-5 card-glow">
               <div className="text-2xl md:text-3xl font-bold font-mono text-cyan-400 mb-1">
                 {metric.value}
               </div>
               <div className="text-xs text-zinc-500 leading-snug">{metric.label}</div>
-            </div>
+            </StaggerItem>
           ))}
-        </div>
+        </StaggerContainer>
       </div>
     </section>
   );

--- a/src/components/sections/SkillsSection.tsx
+++ b/src/components/sections/SkillsSection.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 import { Cloud, GitBranch, Shield, Code2 } from 'lucide-react';
+import { FadeInUp, StaggerContainer, StaggerItem } from '@/components/ui/motion-wrappers';
 
 const skillGroups = [
   {
@@ -30,17 +31,20 @@ export default function SkillsSection() {
   return (
     <section id="skills" className="py-24 border-t border-zinc-800/60">
       <div className="max-w-6xl mx-auto px-6">
-        <p className="section-label mb-4">{t('section_label')}</p>
-        <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 mb-12">
-          {t('title')}
-        </h2>
+        <FadeInUp>
+          <p className="section-label mb-4">{t('section_label')}</p>
+          <h2 className="text-3xl md:text-4xl font-bold text-zinc-100 mb-12">
+            {t('title')}
+          </h2>
+        </FadeInUp>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+        <StaggerContainer className="grid grid-cols-1 md:grid-cols-2 gap-5">
           {skillGroups.map((group) => {
             const Icon = group.icon;
             return (
-              <div
+              <StaggerItem
                 key={group.nameKey}
+                hover
                 className="bg-card border border-zinc-800 rounded-2xl p-6 card-glow"
               >
                 <div className="flex items-center gap-3 mb-5">
@@ -56,10 +60,10 @@ export default function SkillsSection() {
                     </span>
                   ))}
                 </div>
-              </div>
+              </StaggerItem>
             );
           })}
-        </div>
+        </StaggerContainer>
       </div>
     </section>
   );

--- a/src/components/ui/motion-wrappers.tsx
+++ b/src/components/ui/motion-wrappers.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import * as motion from 'motion/react-client';
+
+// ─── Fade-in + slide-up on scroll ──────────────────────────────────────────
+interface FadeInUpProps {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}
+
+export function FadeInUp({ children, delay = 0, className }: FadeInUpProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 28 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: '-72px' }}
+      transition={{ duration: 0.5, delay, ease: [0.25, 0.1, 0.25, 1] }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+// ─── Stagger parent ────────────────────────────────────────────────────────
+const containerVariants = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.09,
+      delayChildren: 0.05,
+    },
+  },
+};
+
+interface StaggerContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function StaggerContainer({ children, className }: StaggerContainerProps) {
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once: true, margin: '-60px' }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+// ─── Stagger child ─────────────────────────────────────────────────────────
+const itemVariants = {
+  hidden: { opacity: 0, y: 22 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.45, ease: [0.25, 0.1, 0.25, 1] as [number, number, number, number] },
+  },
+};
+
+interface StaggerItemProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Adds a subtle upward lift on hover — useful for clickable cards */
+  hover?: boolean;
+}
+
+export function StaggerItem({ children, className, hover = false }: StaggerItemProps) {
+  return (
+    <motion.div
+      variants={itemVariants}
+      whileHover={hover ? { y: -5, transition: { duration: 0.2, ease: 'easeOut' } } : undefined}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

Add scroll-triggered entrance animations and hover lift effects to all four portfolio sections using motion v12 (`motion/react-client`). Introduces a reusable `motion-wrappers.tsx` client-component layer so section files remain server components.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor
- [ ] Docs / config only

## Areas Affected

- `src/components/ui/motion-wrappers.tsx` (new file)
- `src/components/sections/HeroSection.tsx`
- `src/components/sections/AboutSection.tsx`
- `src/components/sections/SkillsSection.tsx`
- `src/components/sections/CaseStudiesSection.tsx`
- `package.json` / `package-lock.json` (motion v12.40.0 added)

## What Changed

Created three reusable animation primitives in `motion-wrappers.tsx`:

| Component | Behavior |
|-----------|----------|
| `FadeInUp` | Opacity + y slide-up on scroll (`whileInView`, fires once) |
| `StaggerContainer` | Variant parent — staggers children at 90 ms intervals |
| `StaggerItem` | Variant child; optional `hover` prop adds −5 px lift on hover |

Applied across sections:
- **Hero** — badge → name → tagline → desc → CTAs cascade in; metrics tiles stagger + hover lift
- **About** — bio block fades in; highlights stagger; experience cards stagger + hover lift
- **Skills** — header fades in; skill-group cards stagger + hover lift
- **Case Studies** — header fades in; case study cards stagger + hover lift

## How to Review

1. Check out the Vercel preview link
2. Scroll through each section and verify elements animate in sequentially
3. Hover over metric tiles, experience cards, skill cards, and case study cards — expect a subtle upward lift
4. Verify no layout shift or flicker on initial page load
5. Test on mobile viewport — animations should play correctly

## Checklist

- [x] Build passes (`npm run build` — 22/22 pages, 0 TS errors)
- [x] No `'use client'` added to section files (RSC boundary preserved)
- [x] Animations use `once: true` — no re-triggering on scroll back up
- [x] Conventional commit format followed
- [x] No sensitive data introduced

## Related Issues

N/A