### PR TITLE
feat(form): wire motion animations into contact form and drawer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,34 +71,4 @@
     font-family: var(--font-family-sans);
   }
 
-  /* Contact drawer slide-down animation */
-  .drawer-enter {
-    animation: drawerSlideDown 0.3s ease forwards;
-  }
-
-  .drawer-exit {
-    animation: drawerSlideUp 0.2s ease forwards;
-  }
-}
-
-@keyframes drawerSlideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes drawerSlideUp {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-12px);
-  }
 }

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -6,6 +6,8 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Send, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import * as motion from 'motion/react-client';
+import { AnimatePresence } from 'motion/react';
 
 const contactSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
@@ -15,6 +17,26 @@ const contactSchema = z.object({
 });
 
 type ContactFormData = z.infer<typeof contactSchema>;
+
+/** Animated inline error beneath a field */
+function FieldError({ message }: { message?: string }) {
+  return (
+    <AnimatePresence>
+      {message && (
+        <motion.p
+          key={message}
+          initial={{ opacity: 0, y: -6 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -4 }}
+          transition={{ duration: 0.18, ease: 'easeOut' }}
+          className="mt-1 text-xs text-red-400"
+        >
+          {message}
+        </motion.p>
+      )}
+    </AnimatePresence>
+  );
+}
 
 export default function ContactForm() {
   const t = useTranslations('Contact');
@@ -70,7 +92,7 @@ export default function ContactForm() {
           className={inputClass}
           placeholder={t('name_placeholder')}
         />
-        {errors.name && <p className="mt-1 text-xs text-red-400">{errors.name.message}</p>}
+        <FieldError message={errors.name?.message} />
       </div>
 
       <div>
@@ -84,7 +106,7 @@ export default function ContactForm() {
           className={inputClass}
           placeholder={t('email_placeholder')}
         />
-        {errors.email && <p className="mt-1 text-xs text-red-400">{errors.email.message}</p>}
+        <FieldError message={errors.email?.message} />
       </div>
 
       <div>
@@ -98,7 +120,7 @@ export default function ContactForm() {
           className={inputClass}
           placeholder={t('subject_placeholder')}
         />
-        {errors.subject && <p className="mt-1 text-xs text-red-400">{errors.subject.message}</p>}
+        <FieldError message={errors.subject?.message} />
       </div>
 
       <div>
@@ -112,12 +134,14 @@ export default function ContactForm() {
           className={`${inputClass} resize-none`}
           placeholder={t('message_placeholder')}
         />
-        {errors.message && <p className="mt-1 text-xs text-red-400">{errors.message.message}</p>}
+        <FieldError message={errors.message?.message} />
       </div>
 
-      <button
+      {/* Send button with press feedback */}
+      <motion.button
         type="submit"
         disabled={isSubmitting}
+        whileTap={!isSubmitting ? { scale: 0.97 } : undefined}
         className="w-full flex items-center justify-center px-4 py-3 bg-zinc-900 border border-zinc-700 text-zinc-100 font-semibold rounded-lg hover:bg-zinc-800 hover:border-cyan-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 text-sm"
       >
         {isSubmitting ? (
@@ -131,21 +155,38 @@ export default function ContactForm() {
             {t('send')}
           </>
         )}
-      </button>
+      </motion.button>
 
-      {submitStatus === 'success' && (
-        <div className="flex items-center text-emerald-400 bg-emerald-400/10 border border-emerald-400/20 rounded-lg p-3 text-sm">
-          <CheckCircle className="h-4 w-4 mr-2 shrink-0" />
-          <span>{t('success')}</span>
-        </div>
-      )}
+      {/* Submit status banners */}
+      <AnimatePresence>
+        {submitStatus === 'success' && (
+          <motion.div
+            key="success"
+            initial={{ opacity: 0, y: 6, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.97 }}
+            transition={{ duration: 0.25, ease: 'easeOut' }}
+            className="flex items-center text-emerald-400 bg-emerald-400/10 border border-emerald-400/20 rounded-lg p-3 text-sm"
+          >
+            <CheckCircle className="h-4 w-4 mr-2 shrink-0" />
+            <span>{t('success')}</span>
+          </motion.div>
+        )}
 
-      {submitStatus === 'error' && (
-        <div className="flex items-center text-red-400 bg-red-400/10 border border-red-400/20 rounded-lg p-3 text-sm">
-          <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
-          <span>{t('error')}</span>
-        </div>
-      )}
+        {submitStatus === 'error' && (
+          <motion.div
+            key="error"
+            initial={{ opacity: 0, y: 6, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.97 }}
+            transition={{ duration: 0.25, ease: 'easeOut' }}
+            className="flex items-center text-red-400 bg-red-400/10 border border-red-400/20 rounded-lg p-3 text-sm"
+          >
+            <AlertCircle className="h-4 w-4 mr-2 shrink-0" />
+            <span>{t('error')}</span>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </form>
   );
 }

--- a/src/components/ui/ContactDrawer.tsx
+++ b/src/components/ui/ContactDrawer.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
+import * as motion from 'motion/react-client';
+import { AnimatePresence } from 'motion/react';
 import ContactForm from '@/components/forms/ContactForm';
 
 interface ContactDrawerProps {
@@ -43,26 +45,32 @@ export default function ContactDrawer({ isOpen, onClose }: ContactDrawerProps) {
     }
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
-
   return (
     /*
      * fixed positioning avoids backdrop-filter containing-block issues.
      * top-16 = nav height (h-16). right-6 matches the nav's px-6 padding.
      */
-    <div
-      ref={panelRef}
-      className="absolute top-[calc(100%+14px)] right-0 z-50 w-[380px] bg-[#0f0f0f] border border-zinc-800 rounded-xl shadow-2xl shadow-black/60 drawer-enter overflow-hidden"
-    >
-      {/* Title bar */}
-      <div className="px-6 pt-6 pb-4 border-b border-zinc-800/60">
-        <p className="text-sm font-medium text-zinc-200">{t('drawer_title')}</p>
-      </div>
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          ref={panelRef}
+          initial={{ opacity: 0, y: -10, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -8, scale: 0.98 }}
+          transition={{ duration: 0.22, ease: [0.25, 0.1, 0.25, 1] as [number, number, number, number] }}
+          className="absolute top-[calc(100%+14px)] right-0 z-50 w-[380px] bg-[#0f0f0f] border border-zinc-800 rounded-xl shadow-2xl shadow-black/60 overflow-hidden"
+        >
+          {/* Title bar */}
+          <div className="px-6 pt-6 pb-4 border-b border-zinc-800/60">
+            <p className="text-sm font-medium text-zinc-200">{t('drawer_title')}</p>
+          </div>
 
-      {/* Form */}
-      <div className="px-6 py-5">
-        <ContactForm />
-      </div>
-    </div>
+          {/* Form */}
+          <div className="px-6 py-5">
+            <ContactForm />
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary

Animate the contact form's validation errors, submit status banners, drawer open/close, and send button using motion v12. The drawer's CSS exit animation was previously dead code — the component unmounted before it could play.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor
- [ ] Docs / config only

## Areas Affected

- `src/components/forms/ContactForm.tsx`
- `src/components/ui/ContactDrawer.tsx`
- `src/app/globals.css` (dead keyframe CSS removed)

## What Changed

- **FieldError** component extracted — `AnimatePresence` + `motion.p` slides each field error down on appearance (y -6→0) and back up on dismiss
- **Submit banners** (success/error) wrapped in `AnimatePresence` + `motion.div` with fade + scale(0.97→1) enter/exit
- **Send button** converted to `motion.button` with `whileTap={{ scale: 0.97 }}`; press feedback suppressed when `isSubmitting`
- **ContactDrawer** `if (!isOpen) return null` replaced with `AnimatePresence` — exit animation now runs before unmount
- **globals.css** `.drawer-enter`, `.drawer-exit`, `drawerSlideDown/Up` keyframes purged (were unreachable)

## How to Review

1. Open the Vercel preview on desktop — click "Say Hello" to open the drawer, check slide-down in and slide-up out
2. Submit the form with empty fields — verify each error slides in smoothly
3. Fix a field — verify the error slides back out
4. Submit a valid form — verify the success/error banner fades + scales in
5. Press and hold the Send button — verify the subtle scale press effect

## Checklist

- [x] Build passes (`npm run build` — 22/22 pages, 0 TS errors)
- [x] Drawer exit animation now actually plays before unmount
- [x] Dead CSS keyframes removed from globals.css
- [x] `whileTap` suppressed during submit to avoid conflict with `disabled`
- [x] Conventional commit format followed

## Related Issues

N/A